### PR TITLE
fix(deps): bump jquery-ui to 1.14.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "express": "^4.17.3",
         "hbs": "~4.2.1",
         "jquery": "^3.5.0",
-        "jquery-ui": "1.12.x",
+        "jquery-ui": "^1.13.2",
         "morgan": "~1.10.1",
         "pg": "^8.21.0",
         "serve-favicon": "^2.5.0",
@@ -1220,10 +1220,13 @@
       "license": "MIT"
     },
     "node_modules/jquery-ui": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/jquery-ui/-/jquery-ui-1.12.1.tgz",
-      "integrity": "sha512-K/kDBMXkTky5LH+gqbMvttU1ipqCTaecKyAFjwHjUnPTVfm5I5PZC7We31iNR3yWtAHNqoxkLoit06lR/gKVlA==",
-      "license": "MIT"
+      "version": "1.14.2",
+      "resolved": "https://registry.npmjs.org/jquery-ui/-/jquery-ui-1.14.2.tgz",
+      "integrity": "sha512-1gSl7PUjyipa2adSr780Ujk16faicrV7PjPPzPtvWk7tTqBnsqp67NNV9jZK2+BIxUPXWSnIUU/LBCgwgGZE+Q==",
+      "license": "MIT",
+      "dependencies": {
+        "jquery": ">=1.12.0 <5.0.0"
+      }
     },
     "node_modules/json-bigint": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "express": "^4.17.3",
     "hbs": "~4.2.1",
     "jquery": "^3.5.0",
-    "jquery-ui": "1.12.x",
+    "jquery-ui": "^1.13.2",
     "morgan": "~1.10.1",
     "pg": "^8.21.0",
     "serve-favicon": "^2.5.0",

--- a/views/layout.hbs
+++ b/views/layout.hbs
@@ -5,9 +5,9 @@
     <link rel="stylesheet" href="/stylesheets/main.css">
     <link rel="shortcut icon" href="images/favicon.ico" type="image/x-icon">
     {{#if suggester}}
-    <link rel="stylesheet" href="//code.jquery.com/ui/1.12.1/themes/base/jquery-ui.css">
-    <script src="https://code.jquery.com/jquery-1.12.4.js"></script>
-    <script src="https://code.jquery.com/ui/1.12.1/jquery-ui.js"></script>
+    <link rel="stylesheet" href="//cdn.jsdelivr.net/npm/jquery-ui@1.14.2/dist/themes/base/jquery-ui.min.css">
+    <script src="https://cdn.jsdelivr.net/npm/jquery@3.7.1/dist/jquery.min.js"></script>
+    <script src="//cdn.jsdelivr.net/npm/jquery-ui@1.14.2/dist/jquery-ui.min.js"></script>
     <script>
       $(document).ready( function() {
         $( "#search_box" ).autocomplete({


### PR DESCRIPTION
## Summary
Closes dependabot alerts **#29, #30, #31, #38** (XSS vulnerabilities in jquery-ui).

## Changes
- `package.json`: bump \`jquery-ui\` from \`1.12.x\` → \`^1.13.2\` (resolved to 1.14.2)
- `views/layout.hbs`: update CDN URLs to use \`jquery-ui@1.14.2\` via jsDelivr
- `views/layout.hbs`: also bump CDN jQuery \`1.12.4\` → \`3.7.1\` (jQuery 1.12.4 has its own CVEs)
- `package-lock.json`: refreshed

## Vulnerability Details
| Alert | CVE | Description |
|---|---|---|
| #29 | CVE-2021-41182 | XSS in \`altField\` option of Datepicker |
| #30 | CVE-2021-41184 | XSS in \`of\` option of \`.position()\` util |
| #31 | CVE-2021-41183 | XSS in \`*Text\` options of Datepicker |
| #38 | CVE-2022-31160 | XSS refreshing checkboxradio with HTML-like label |

## Notes
- \`code.jquery.com/ui/1.13.x\` and \`1.14.x\` CDN paths return 404 — switched to **jsDelivr** which hosts them
- jQuery UI 1.14.x is API-compatible with 1.12.x for the autocomplete widget used here; no JS code changes needed
- jQuery UI 1.14.x supports jQuery 1.8+ and 3.x — safe to also bump the CDN jQuery to 3.7.1